### PR TITLE
Fix build error with DominantColors Library

### DIFF
--- a/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
+++ b/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
@@ -1661,7 +1661,7 @@
 			repositoryURL = "https://github.com/DenDmitriev/DominantColors";
 			requirement = {
 				kind = exactVersion;
-				minimumVersion = 1.0.9;
+				version = 1.0.9;
 			};
 		};
 		418D5DB42B910F4900589E17 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
@milanvarady I have temporarily switch from  `minimumVersion` to `exactVersion` of DominantColors for time being. 

```
			repositoryURL = "https://github.com/DenDmitriev/DominantColors";
			requirement = {
				kind = exactVersion;
				version = 1.0.9;
```