### PR TITLE
Update DominantColors Version

### DIFF
--- a/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
+++ b/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
@@ -1673,7 +1673,7 @@
 			repositoryURL = "https://github.com/DenDmitriev/DominantColors";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.1.7;
+				minimumVersion = 1.1.9;
 			};
 		};
 		418D5DB42B910F4900589E17 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
@milanvarady FYI,

https://github.com/DenDmitriev/DominantColors/blob/main/Package.swift

The package name is now renamed from `DominantColors` to `DCLib`. 

Hence, the resulting .bundle file within `Marker Data.app/Contents/Resources/` called `DCLib_DominantColors.bundle`

```swift
// swift-tools-version: 5.9
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "DCLib",
    platforms: [
        .macOS(.v11),
        .iOS(.v13),
        .tvOS(.v13),
        .watchOS(.v6)
    ],
    products: [
        // Products define the executables and libraries a package produces, and make them visible to other packages.
        .library(
            name: "DominantColors",
            targets: ["DominantColors"]),
    ],
    dependencies: [
        // Dependencies declare other packages that this package depends on.
        // .package(url: /* package url */, from: "1.0.0"),
    ],
    targets: [
        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
        // Targets can depend on other targets in this package, and on products in packages this package depends on.
        .target(
            name: "DominantColors",
            dependencies: [], 
            path: "Sources/DominantColors",
            resources: [.process("Resources/Media.xcassets")]),
        .testTarget(
            name: "DominantColorsTests",
            dependencies: ["DominantColors"],
            resources: [.process("Media.xcassets")]),
    ]
)
```