### PR TITLE
Fix Dropbox setup failing on macOS Tahoe due to Apple restrictions

### DIFF
--- a/Source/Marker Data/Marker Data/Models/Database/Profile Models/Dropbox/DropboxSetupModel.swift
+++ b/Source/Marker Data/Marker Data/Models/Database/Profile Models/Dropbox/DropboxSetupModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AppKit
 import OSLog
 
 @MainActor
@@ -46,9 +47,12 @@ class DropboxSetupModel: ObservableObject {
         try data.write(to: URL.dropboxTokenJSON)
     }
     
+    /// Launches Terminal with the airlift Dropbox auth command using a .command file,
+    /// avoiding NSAppleScript which requires Apple Events permissions
+    /// that macOS Tahoe restricts.
     private func launchTerminal() throws {
         guard let airliftURL = Bundle.main.url(forResource: "airlift", withExtension: nil) else {
-            Self.logger.error("Failed to upload to Notion: csv2notion executable not found")
+            Self.logger.error("Failed to find airlift executable")
             throw DatabaseUploadError.csv2notionExecutableNotFound
         }
         
@@ -57,18 +61,22 @@ class DropboxSetupModel: ObservableObject {
         let logPath = URL.logsFolder
             .appendingPathComponent("airlift_log.txt", conformingTo: .plainText).path(percentEncoded: false)
         
-        let scriptSource = """
-tell application "Terminal"
-    activate
-    do script "\\"\(executablePath)\\" --dropbox-token \\"\(dropboxJSONPath)\\" --dropbox-refresh-token --log \\"\(logPath)\\" --verbose"
-end tell
-"""
-        let script = NSAppleScript(source: scriptSource)
-        var errorInfo: NSDictionary? = nil
-        let result = script?.executeAndReturnError(&errorInfo)
+        let scriptContent = """
+        #!/bin/bash
+        "\(executablePath)" --dropbox-token "\(dropboxJSONPath)" --dropbox-refresh-token --log "\(logPath)" --verbose
+        """
         
-        if result == nil {
-            Self.logger.error("Failed to launch Terminal. \(errorInfo.debugDescription)")
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("marker_data_dropbox_setup.command")
+        
+        try scriptContent.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: scriptURL.path(percentEncoded: false)
+        )
+        
+        if !NSWorkspace.shared.open(scriptURL) {
+            Self.logger.error("Failed to open .command file in Terminal")
             throw DropboxError.terminalLaunchError
         }
     }
@@ -105,8 +113,19 @@ enum AirtableAuthRequestStatus {
     case success
 }
 
-enum DropboxError: Error {
+enum DropboxError: Error, LocalizedError {
     case airliftGetURLError
     case failedToFindURL
     case terminalLaunchError
+
+    var errorDescription: String? {
+        switch self {
+        case .airliftGetURLError:
+            return "Failed to get airlift URL."
+        case .failedToFindURL:
+            return "Failed to find URL."
+        case .terminalLaunchError:
+            return "Failed to launch Terminal. Please ensure Marker Data has permission to open Terminal in System Settings > Privacy & Security."
+        }
+    }
 }

--- a/Source/Marker Data/Marker Data/Views/Detail Views/Database/Create Sheet/DropboxSetupView.swift
+++ b/Source/Marker Data/Marker Data/Views/Detail Views/Database/Create Sheet/DropboxSetupView.swift
@@ -13,6 +13,7 @@ struct DropboxSetupView: View {
     @StateObject var dropboxSetupModel = DropboxSetupModel()
     
     @State var showAppKeyError = false
+    @State var appKeyErrorMessage = ""
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -36,6 +37,7 @@ struct DropboxSetupView: View {
                             do {
                                 try await dropboxSetupModel.saveAppKeyAndLaunchTerminal(appKey)
                             } catch {
+                                appKeyErrorMessage = error.localizedDescription
                                 showAppKeyError = true
                                 dropboxSetupModel.authRequestStatus = .notInitiated
                             }
@@ -57,7 +59,9 @@ struct DropboxSetupView: View {
                         .foregroundStyle(.green)
                 }
             }
-            .alert("Failed to save app key", isPresented: $showAppKeyError) {}
+            .alert("Dropbox Setup Failed", isPresented: $showAppKeyError) {} message: {
+                Text(appKeyErrorMessage)
+            }
             
             Text("Clicking **Continue** will launch the Terminal. Follow the on-screen instructions for the rest of the setup process.")
                 .fontWeight(.thin)


### PR DESCRIPTION
@milanvarady 

With the help of Cursor AI, I was attempting to fix the issue where on macOS Tahoe, I was not able to create the Dropbox token. Pressing continue would result in `Failed to save app key` error.

---

**From Cursor AI** 

I've found the bug. Let me trace through the exact failure path:

When "Continue" is pressed, DropboxSetupModel.saveAppKeyAndLaunchTerminal() calls two operations:

1. saveAppKeyToDisk() -- writes JSON to disk
2. launchTerminal() -- uses NSAppleScript to tell Terminal.app to run airlift

The launchTerminal() method at line 49-74 of DropboxSetupModel.swift uses AppleScript to control Terminal.app:

```
    private func launchTerminal() throws {
        // ...
        let scriptSource = """
tell application "Terminal"
    activate
    do script "..."
end tell
"""
        let script = NSAppleScript(source: scriptSource)
        var errorInfo: NSDictionary? = nil
        let result = script?.executeAndReturnError(&errorInfo)
        
        if result == nil {
            Self.logger.error("Failed to launch Terminal. \(errorInfo.debugDescription)")
            throw DropboxError.terminalLaunchError
        }
    }
```

**The root cause:** 

The entitlements file lists com.apple.security.scripting-targets only for Final Cut Pro -- Terminal.app is not listed. On macOS Sonoma, the system would show a TCC permission prompt and allow it. On macOS Tahoe, Apple has tightened Apple Events automation restrictions, and NSAppleScript controlling Terminal.app is now blocked or denied.

The view's alert also misleadingly says "Failed to save app key" regardless of whether the disk write or Terminal launch failed, since both errors are caught in the same block.

**The fix:** 

Replace the NSAppleScript approach with a .command file opened via NSWorkspace, which is the standard macOS mechanism for running scripts in Terminal and doesn't require Apple Events entitlements. Also improve the error alert to be more descriptive.

## Summary of Changes

### Root Cause

The launchTerminal() method in DropboxSetupModel used NSAppleScript to send an Apple Event to Terminal.app (tell application "Terminal" ... do script ...). While the app's entitlements include com.apple.security.automation.apple-events, the scripting-targets only lists Final Cut Pro -- Terminal.app is not a listed scripting target. On macOS Sonoma, the system would show a TCC permission prompt and allow it. On macOS Tahoe, Apple has tightened Apple Events automation restrictions, causing the script execution to fail silently (returning nil), which threw DropboxError.terminalLaunchError.

Fix (2 files changed)
**DropboxSetupModel.swift:**

1. Replaced the NSAppleScript approach with a .command file strategy: writes the airlift command to a temporary marker_data_dropbox_setup.command file, makes it executable (chmod 755), and opens it via NSWorkspace.shared.open(). macOS natively opens .command files in Terminal without requiring Apple Events entitlements.
2. Added import AppKit for NSWorkspace.
3. Added LocalizedError conformance to DropboxError with descriptive messages.

**DropboxSetupView.swift:**

1. Changed the misleading alert title from "Failed to save app key" to "Dropbox Setup Failed".
2. Added `@State` var appKeyErrorMessage to capture and display the actual error description in the alert body, so users can distinguish between a disk write failure vs. a Terminal launch failure.

---

After making this changes, I was able to create the dropbox token by press pressing `continue` button and it would trigger opening the terminal to fire up `airlift` binary to update and create the Refresh Token.

Could you review the changes if they are correct? If everything is okay we can merge this into the current `liquid-glass` branch.

Thank you.