### PR TITLE
Hide `.xmlPath` in Merge Only Section

### DIFF
--- a/Source/Marker Data/Marker Data/Views/Detail Views/Database/Create Sheet/NotionFormView.swift
+++ b/Source/Marker Data/Marker Data/Views/Detail Views/Database/Create Sheet/NotionFormView.swift
@@ -55,7 +55,7 @@ struct NotionFormView: View {
             }
             
             ZStack {
-                List(ExportField.allCases) { mergeColumn in
+                List(ExportField.allCases.filter { $0 != .xmlPath }) { mergeColumn in
                     HStack {
                         Toggle("", isOn: Binding<Bool>(
                             get: {


### PR DESCRIPTION
@milanvarady

With the help of Cursor AI, I believe I have found the exact syntax to hide/filter out `XML Path` check box.

It does not show up now. 

<img width="245" height="180" alt="hide-xml-path" src="https://github.com/user-attachments/assets/e976b82a-6731-45f3-81fd-648611ad10d4" />

---

**From Cursor AI**

The List now filters out .xmlPath so "XML Path" will no longer appear in the Merge Only section. The change is minimal — just a .filter { $0 != .xmlPath } applied to ExportField.allCases on line 58.

---

Please check if this is correct, if all okay, you can merge it into `liquid-glass` branch,

Thank you.