### PR TITLE
Added `Allow UTF-8 in MIDI Export Profile` Setting

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,9 +17,21 @@ You are working in the **Marker Data** repository: a macOS Swift/SwiftUI app tha
 ## Swift / SwiftUI conventions
 - Format Swift with SwiftFormat (see CONTRIBUTING.md).
 - Models that drive UI are `@MainActor` and mutate on main; extraction uses `TaskGroup` with cancellation.
-- Settings live in `~/Library/Application Support/Marker Data/` (see `URLExtension.swift`). Schema is versioned; any change to `SettingsStore` must:
-  - Bump `SettingsStore.version`
-  - Add a migration in `SettingsVersioningManager.upgradeVersion(...)`.
+
+## Settings system (required reading for preference changes)
+- Read **AGENT.md** → *Settings system* and **ARCHITECTURE.md** → *Settings system* before adding or changing persisted preferences.
+- Active settings: `~/Library/Application Support/Marker Data/preferences.json`. Named presets: `Configurations/*.json`. Both use `SettingsStore` (`SettingsStore.swift`).
+- `SettingsContainer` (`SettingsContainer.swift`) holds the active `store`, auto-saves on change, and manages configuration CRUD.
+- On launch, `SettingsVersioningManager.updateAll()` migrates JSON **before** decode — migrations are dict-based in `SettingsVersioningManager.upgradeVersion(...)`, one step per version increment.
+- UI binds via `@EnvironmentObject SettingsContainer` and `$settings.store.<property>`.
+- Export pipeline reads settings through `SettingsStore.markersExtractorSettings(fcpxmlFileUrl:)` → `MarkersExtractor.Settings` — wire new export-related fields there.
+- `RolesManager` reads/writes `preferences.json` directly (Workflow Extension sync) — keep `roles` compatible.
+- **Any new/changed/renamed persisted `SettingsStore` property:**
+  1. Bump `SettingsStore.version`
+  2. Add migration `case` for the previous version
+  3. Add UI binding
+  4. Wire `markersExtractorSettings` if export-related
+  5. Never remove/rename JSON keys without a migration
 
 ## Pitfalls to avoid
 - Do not remove or rename persisted settings keys without a migration.

--- a/AGENT.md
+++ b/AGENT.md
@@ -45,16 +45,47 @@ Recommended:
   - Extraction uses `TaskGroup` for parallelism; cancellation is supported via `Task.cancel()`.
 - **Persistence**:
   - Settings are stored as JSON in `~/Library/Application Support/Marker Data/` (see `URLExtension.swift`).
-  - `SettingsStore.version` is authoritative; schema changes must include migrations.
+  - See **Settings system** below and `ARCHITECTURE.md` for the full schema, migration, and UI wiring model.
 - **External tools**:
   - Notion/Airtable uploads are done by spawning bundled executables; treat them as opaque.
   - Progress parsing depends on `NN%` output lines.
 
+## Settings system (read before changing preferences)
+
+Marker Data settings are **versioned JSON**. The active store is `preferences.json`; named presets live in `Configurations/*.json`. Both use the same `SettingsStore` schema.
+
+**Core files:** `SettingsStore.swift`, `SettingsContainer.swift`, `SettingsVersioningManager.swift`. Full detail: `ARCHITECTURE.md` → *Settings system*.
+
+### How it works (short)
+
+1. **Launch:** `SettingsVersioningManager.updateAll()` migrates every settings JSON on disk (dict-based, step-by-step) **before** `JSONDecoder` loads `SettingsStore`.
+2. **Runtime:** `SettingsContainer.store` is `@Published`; UI binds via `@EnvironmentObject` and `$settings.store.<property>`.
+3. **Auto-save:** any change to `store` writes `preferences.json` immediately.
+4. **Extraction:** `SettingsStore.markersExtractorSettings(fcpxmlFileUrl:)` maps store fields → `MarkersExtractor.Settings` (not automatic — wire new export-related fields here).
+5. **Roles exception:** `RolesManager` reads/writes `preferences.json` directly for Workflow Extension sync — do not break that contract.
+
+### Checklist: add or change a persisted setting
+
+| Step | Action |
+|------|--------|
+| 1 | Add property to `SettingsStore`; set default in `defaults()` |
+| 2 | **Bump `SettingsStore.version`** (static `let version`) |
+| 3 | Add `case <oldVersion>:` in `SettingsVersioningManager.upgradeVersion(dict:version:)` |
+| 4 | Add UI toggle/picker in the relevant settings view under `Views/Detail Views/` |
+| 5 | If export-related: pass through `markersExtractorSettings(fcpxmlFileUrl:)` |
+| 6 | If MarkersExtractor gained a new API: bump package in `project.pbxproj` |
+| 7 | Confirm old JSON files migrate and the app still loads settings (definition of done) |
+
+**Always migrate** when adding/removing/renaming persisted keys. **Never** rely on `Codable` defaults alone for existing on-disk files.
+
+**Reference implementation:** `allowUTF8InMIDIExport` (issue #148) — property, v7→v8 migration, `FileSettingsView` toggle, `isMIDIFileUTF8EncodingAllowed` in `markersExtractorSettings`, MarkersExtractor 0.4.6.
+
 ## “When you change X, also change Y”
-- **SettingsStore changes**:
+- **SettingsStore changes** (see checklist above):
   - Increment `SettingsStore.version`.
   - Add a new migration step in `SettingsVersioningManager.upgradeVersion(...)`.
   - Ensure UI bindings (Settings views) remain consistent.
+  - Wire `markersExtractorSettings(...)` when the setting affects extraction.
 - **New export fields / overlays**:
   - Update UI in `OverlaySettingsView` (and any Notion merge-only lists).
   - Ensure the export pipeline supports it through `MarkersExtractor` / manifest fields.
@@ -68,7 +99,7 @@ Recommended:
   - Workflow Extension communicates via `DistributedNotificationCenter` and shared disk files in Movies cache.
 
 ## Common pitfalls
-- **Don’t break migrations**: settings JSONs in the wild must be upgradable; never remove keys without a migration plan.
+- **Don’t break migrations**: settings JSONs in the wild must be upgradable; never remove keys without a migration plan. See **Settings system** above.
 - **Entitlements & signing**: changes that touch Apple Events, sandboxing, or extension behavior may require entitlement updates.
 - **Install location**: app expects to run from `/Applications` (warning is shown in `ContentView`).
 - **Opaque helpers**: `airlift` / `csv2notion_neo` are binaries; don’t assume internal behavior beyond CLI contracts used in `DatabaseUploader`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,10 +72,90 @@ Defined by `URLExtension.swift` and created/validated by `LibraryFolders.checkAn
   - `Logs/*.txt`
 - `~/Movies/Marker Data Cache/` (FCP export cache + workflow extension handoff file)
 
-### Settings schema and migration
-- Persisted type: `SettingsStore` (schema version is `SettingsStore.version`)
-- Loader/controller: `SettingsContainer`
-- Migration: `SettingsVersioningManager.updateAll()` upgrades `preferences.json` and every config JSON in-place to current schema.
+### Settings system
+
+Marker Data persists almost all user preferences as versioned JSON. Understanding this system is required before adding or changing any setting.
+
+#### Key types and files
+
+| File | Role |
+|------|------|
+| `Models/Settings/SettingsStore.swift` | `Codable` value type holding the full settings schema; `static let version` is the **current schema number** (check the file — do not hard-code in docs) |
+| `Models/Settings/SettingsContainer.swift` | `@MainActor` `ObservableObject` wrapping the active `store`; loads/saves, manages named configurations, auto-saves on change |
+| `Models/Settings/SettingsVersioningManager.swift` | Dict-based migrations run **before** `JSONDecoder` decode |
+| `Models/Settings/SettingsModels.swift` | Supporting enums/types used by `SettingsStore` (e.g. `ImageMode`, `FontNameType`) |
+| `Models/Settings/MarkersExtractorModelExtensions.swift` | Display-name / `Codable` extensions for MarkersExtractor types |
+| `Utilities/Extensions/URLExtension.swift` | Canonical paths under Application Support |
+
+#### What gets persisted where
+
+| Path | Contents |
+|------|----------|
+| `preferences.json` | **Active** settings — what the app uses right now |
+| `Configurations/{name}.json` | **Named configuration presets** (toolbar picker); same schema as `preferences.json` |
+| `Database Profiles/` | Notion/Airtable credentials — **separate** from `SettingsStore`; managed by `DatabaseManager` |
+| `Resources/DefaultConfiguration.json` | Legacy bundle resource; **not** the live settings source (URL helper exists but is unused) |
+
+Both `preferences.json` and every `Configurations/*.json` file include a `"version"` integer that must match `SettingsStore.version` after migration.
+
+#### Runtime lifecycle (app launch)
+
+```
+SettingsContainer.init()
+  → SettingsVersioningManager.updateAll()     // migrate JSON dicts on disk
+  → load preferences.json into store          // JSONDecoder → SettingsStore
+  → load all Configurations/*.json
+  → save preferences.json (normalize on disk)
+  → subscribe to $store → auto-save on every change
+```
+
+Migrations run **synchronously at launch** (via `Task.synchronous`) before any settings are decoded. If migration fails for a file, it is logged; decode may then fail for that file.
+
+#### Schema versioning
+
+- `SettingsStore.version` (static) = schema the **current app code** expects.
+- `version` (per JSON file) = schema that file was written with.
+- On launch, for each settings JSON: while `file.version < SettingsStore.version`, apply one `upgradeVersion(dict:version:)` step, increment `version`, save file.
+
+Migrations operate on `[String: Any]` dictionaries — **not** on Swift `Codable` — so renames, nested dict updates, and default injection are explicit. Each `case N` in `upgradeVersion` handles the upgrade **from** version `N` **to** `N + 1`.
+
+**Example (v7 → v8):** added `allowUTF8InMIDIExport` with default `false` for existing users.
+
+#### Auto-save and configurations
+
+- SwiftUI views bind to `$settings.store.<property>` via `@EnvironmentObject SettingsContainer`.
+- Any change to `store` triggers `saveAsCurrent()` → writes `preferences.json`.
+- Named configurations are separate files; **saving a configuration** (`saveCurrentAs`, duplicate, etc.) writes `Configurations/{name}.json`.
+- `unsavedChanges` compares in-memory `store` to the on-disk file for the active configuration.
+- Configuration CRUD UI uses `ConfigurationsViewModel` as a thin facade over `SettingsContainer`.
+
+#### Bridge to extraction (`markersExtractorSettings`)
+
+Not every `SettingsStore` field maps 1:1 to the UI. Extraction reads settings through:
+
+`SettingsStore.markersExtractorSettings(fcpxmlFileUrl:)` → `MarkersExtractor.Settings`
+
+When adding a setting that affects extraction/export, wire it here (and bump MarkersExtractor dependency if the library adds a new parameter). Example: `allowUTF8InMIDIExport` → `isMIDIFileUTF8EncodingAllowed`.
+
+#### Exception: Roles (`RolesManager`)
+
+FCP role enable/disable is stored in `preferences.json` but **`RolesManager` reads/writes the file directly** (not via `SettingsContainer`) so the Workflow Extension can share the same file. Changes to `roles` must remain compatible with both the main app and the extension; cross-process sync uses `DistributedNotificationCenter` (`.rolesChanged`).
+
+#### Checklist: adding or changing a persisted setting
+
+1. Add property to `SettingsStore` with a default in `defaults()`.
+2. **Increment** `SettingsStore.version` by 1.
+3. Add `case <previousVersion>:` in `SettingsVersioningManager.upgradeVersion` — inject the new key (use `SettingsStore.defaults()` for default values) or migrate renamed keys.
+4. Add UI binding in the appropriate settings view (`Views/Detail Views/...`).
+5. If it affects extraction: update `markersExtractorSettings(fcpxmlFileUrl:)`.
+6. If it affects MarkersExtractor API: bump the Swift package version in `Marker Data.xcodeproj`.
+7. Verify existing `preferences.json` and `Configurations/*.json` on disk upgrade cleanly (definition of done).
+
+**When you must migrate:** new persisted property, renamed JSON key, removed property, changed nested structure, or any change that would break `JSONDecoder` decode of older files.
+
+**When migration is not needed:** UI-only changes, recalculating defaults for **new** installs only, or settings stored outside `SettingsStore` (e.g. database profiles).
+
+**Never** remove or rename JSON keys without a migration step — users keep settings across app updates.
 
 ## Core flows
 ### 1) Extract flow (interactive)
@@ -145,7 +225,7 @@ Implementation:
 - `SidebarSelectionSwitcher` forces UI to the Extract panel on those events.
 
 ## UI architecture
-SwiftUI views generally bind directly into `SettingsContainer.store` (a published `SettingsStore`), so changing UI fields will auto-save current settings.
+SwiftUI views generally bind directly into `SettingsContainer.store` (a published `SettingsStore`), so changing UI fields will auto-save to `preferences.json`. See **Settings system** for the full persistence, migration, and configuration model.
 
 Notable UI modules:
 - **General settings**: File, Roles, Notifications, Updates

--- a/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
+++ b/Source/Marker Data/Marker Data.xcodeproj/project.pbxproj
@@ -1885,7 +1885,7 @@
 			repositoryURL = "https://github.com/TheAcharya/MarkersExtractor";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.5;
+				minimumVersion = 0.4.6;
 			};
 		};
 		4155B72A2B668C0D008D3505 /* XCRemoteSwiftPackageReference "swift-log-oslog" */ = {

--- a/Source/Marker Data/Marker Data/Models/Settings/SettingsStore.swift
+++ b/Source/Marker Data/Marker Data/Models/Settings/SettingsStore.swift
@@ -11,7 +11,7 @@ import MarkersExtractor
 
 struct SettingsStore: Sendable, Codable, Hashable, Equatable, Identifiable {
     /// Used for versioning
-    static let version: Int = 7
+    static let version: Int = 8
     var version: Int = Self.version
 
     var name: String
@@ -36,6 +36,7 @@ struct SettingsStore: Sendable, Codable, Hashable, Equatable, Identifiable {
     var enabledSubframes: Bool
     var includeDisabledClips: Bool
     var enabledNoMedia: Bool
+    var allowUTF8InMIDIExport: Bool
 
     var IDNamingMode: MarkerIDMode
     var markersSource: MarkersSource
@@ -43,7 +44,7 @@ struct SettingsStore: Sendable, Codable, Hashable, Equatable, Identifiable {
 
     // MARK: Overall image size settings
 
-    // If .noOverride image size, image width andd image hight will be ignored
+    // If .noOverride image size, image width and image hight will be ignored
     var overrideImageSize: OverrideImageSizeOption
     
     // Will be ignored if override image size is off
@@ -136,6 +137,7 @@ struct SettingsStore: Sendable, Codable, Hashable, Equatable, Identifiable {
             enabledSubframes: false,
             includeDisabledClips: false, 
             enabledNoMedia: false,
+            allowUTF8InMIDIExport: false,
             IDNamingMode: .timelineNameAndTimecode,
             markersSource: .markers,
             useChapterMarkerThumbnails: false,
@@ -223,6 +225,7 @@ struct SettingsStore: Sendable, Codable, Hashable, Equatable, Identifiable {
             imageSizePercent: imageSizePercent,
             gifFPS: Double(self.GIFFPS),
             gifSpan: TimeInterval(self.GIFLength),
+            isMIDIFileUTF8EncodingAllowed: self.allowUTF8InMIDIExport,
             idNamingMode: self.IDNamingMode,
             imageLabels: self.overlays,
             imageLabelCopyright: self.copyrightText,

--- a/Source/Marker Data/Marker Data/Models/Settings/SettingsVersioningManager.swift
+++ b/Source/Marker Data/Marker Data/Models/Settings/SettingsVersioningManager.swift
@@ -88,6 +88,8 @@ struct SettingsVersioningManager {
                     dict["IDNamingMode"] = "timelineNameAndTimecode"
                 }
             }
+        case 7:
+            dict["allowUTF8InMIDIExport"] = SettingsStore.defaults().allowUTF8InMIDIExport
         default:
             throw VersioningError.invalidVersion
         }

--- a/Source/Marker Data/Marker Data/Resources/DefaultConfiguration.json
+++ b/Source/Marker Data/Marker Data/Resources/DefaultConfiguration.json
@@ -4,6 +4,7 @@
     "selectedImageMode": 0,
     "enabledSubframes": false,
     "enabledNoMedia": false,
+    "allowUTF8InMIDIExport": false,
     "selectedIDNamingMode": 0,
     "selectedMarkersSource": "markers",
     "overrideImageSize": 0,

--- a/Source/Marker Data/Marker Data/Views/Detail Views/General Settings/FileSettingsView.swift
+++ b/Source/Marker Data/Marker Data/Views/Detail Views/General Settings/FileSettingsView.swift
@@ -65,6 +65,8 @@ struct FileSettingsView: View {
                 Toggle("Use Chapter Marker Pin Image", isOn: $settings.store.useChapterMarkerThumbnails)
                 
                 Toggle("Skip Image Generation", isOn: $settings.store.enabledNoMedia)
+
+                Toggle("Allow UTF-8 in MIDI Export Profile", isOn: $settings.store.allowUTF8InMIDIExport)
             }
         }
     }


### PR DESCRIPTION
@milanvarady With the help of Cursor AI, I attempted to address #148 by adding `Allow UTF-8 in MIDI Export Profile` under General Settings. Could you please review whether the codebase changes have been implemented correctly? Thank you.

<img width="485" height="193" alt="MIDI Export Profile-01" src="https://github.com/user-attachments/assets/dd8ce276-834c-45ec-afa8-dd0e9a6e65a8" />

<hr>

@orchetect 

I did some quick tests with MIDI Export profile.

I was able to see Chinese Characters when `Allow UTF-8 in MIDI Export Profile` was checked.

<img width="1044" height="490" alt="MIDI Export Profile-02" src="https://github.com/user-attachments/assets/d3b9cc60-6d2b-4a29-8d13-0134fe4b2c31" />

When it is unchecked, I got `????`

<img width="984" height="515" alt="MIDI Export Profile-03" src="https://github.com/user-attachments/assets/c756c506-3770-49b8-bef5-4f363a315e4b" />

I believe this is how it is supposed to work in Logic and other DAWs, though I do not have access to other DAWs to confirm. Thanks.